### PR TITLE
don't declare width in .tag a

### DIFF
--- a/static/styles/_tag.scss
+++ b/static/styles/_tag.scss
@@ -32,7 +32,6 @@
     padding: $padding-y $padding-x;
     border-radius: inherit;
     color: currentColor;
-    width: calc(100% + #{$padding-x * 2});
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
This caused a bug in Safari (yep I'm that guy again) that showed the overflow all the time. Disabling this width declaration doesn't seem to have a visual change, but it does fix the overflow for me.